### PR TITLE
Add CLIENT_ID constant and update XsenseApi

### DIFF
--- a/src/api/XsenseApi.ts
+++ b/src/api/XsenseApi.ts
@@ -8,7 +8,7 @@ import {
   CognitoUserSession,
 } from 'amazon-cognito-identity-js';
 import { MqttClient, connect as mqttConnect } from 'mqtt';
-import { API_HOST, USER_POOL_ID } from './constants';
+import { API_HOST, USER_POOL_ID, CLIENT_ID } from './constants';
 import { DeviceInfo, GetDeviceListResponse, GetIotCredentialResponse, IotCredentials } from './types';
 
 export class XsenseApi extends EventEmitter {
@@ -31,7 +31,7 @@ export class XsenseApi extends EventEmitter {
     this.log = log;
     this.userPool = new CognitoUserPool({
       UserPoolId: USER_POOL_ID,
-      ClientId: '',
+      ClientId: CLIENT_ID,
     });
     this.user = new CognitoUser({
       Username: this.email,

--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -3,5 +3,6 @@
  */
 export const REGION = 'eu-central-1';
 export const USER_POOL_ID = 'eu-central-1_Q24jPE111';
+export const CLIENT_ID = '5sg2fo5o72pc0026unprdsdtnq';
 
 export const API_HOST = 'https://api.xsense.io';


### PR DESCRIPTION
## Summary
- add `CLIENT_ID` to constants
- use `CLIENT_ID` when constructing the Cognito user pool
- build project

## Testing
- `npm run build`
- `npm test` *(fails: Request failed with status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68694e1d723c8324ab5066e90068c77a