### PR TITLE
Fix Cognito credentials by fetching config dynamically

### DIFF
--- a/__tests__/XsenseApi.test.ts
+++ b/__tests__/XsenseApi.test.ts
@@ -49,6 +49,19 @@ describe('XsenseApi', () => {
     // Reset mocks before each test
     jest.clearAllMocks();
     nock.cleanAll();
+    const encoded = Buffer.from('abcdsecret').toString('base64');
+    nock(API_HOST)
+      .post('/app')
+      .reply(200, {
+        reCode: 200,
+        reMsg: 'OK',
+        reData: {
+          clientId: 'test-client',
+          clientSecret: encoded,
+          cgtRegion: 'eu-central-1',
+          userPoolId: 'eu-central-1_test',
+        },
+      });
     api = new XsenseApi(username, password, mockLogger);
   });
 

--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -1,8 +1,7 @@
 /**
  * Constants sourced from the X-Sense (Android) app and python-xsense library.
  */
-export const REGION = 'eu-central-1';
-export const USER_POOL_ID = 'eu-central-1_Q24jPE111';
-export const CLIENT_ID = '5sg2fo5o72pc0026unprdsdtnq';
-
-export const API_HOST = 'https://api.xsense.io';
+export const API_HOST = 'https://api.x-sense-iot.com';
+export const CLIENT_TYPE = '1';
+export const APP_VERSION = 'v1.22.0_20240914.1';
+export const APP_CODE = '1220';

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -32,3 +32,16 @@ export interface GetIotCredentialResponse {
   msg: string;
   data: IotCredentials;
 }
+
+export interface ClientInfo {
+  clientId: string;
+  clientSecret: string;
+  cgtRegion: string;
+  userPoolId: string;
+}
+
+export interface GetClientInfoResponse {
+  reCode: number;
+  reMsg: string;
+  reData: ClientInfo;
+}


### PR DESCRIPTION
## Summary
- fetch Cognito client configuration from `/app` endpoint
- update constants and API client to disable proxies
- expose client info types
- adjust tests for new initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686950f385c48324bbfd17397e3094a4