### PR TITLE
Fix MQTT credential handling

### DIFF
--- a/__tests__/XsenseApi.test.ts
+++ b/__tests__/XsenseApi.test.ts
@@ -221,8 +221,8 @@ describe('XsenseApi', () => {
     ];
     const mockCreds = {
       iotEndpoint: 'test.iot.endpoint',
-      accessKey: 'key',
-      secretKey: 'secret',
+      accessKeyId: 'key',
+      secretAccessKey: 'secret',
       sessionToken: 'token',
       expiration: new Date(Date.now() + 3600 * 1000).toISOString(),
     };
@@ -256,7 +256,7 @@ describe('XsenseApi', () => {
 
       expect(mockedMqttConnect).toHaveBeenCalledWith(expect.objectContaining({
         host: mockCreds.iotEndpoint,
-        accessKeyId: mockCreds.accessKey,
+        accessKeyId: mockCreds.accessKeyId,
       }));
 
       // Simulate the 'connect' event to trigger subscriptions

--- a/src/api/XsenseApi.ts
+++ b/src/api/XsenseApi.ts
@@ -284,8 +284,8 @@ export class XsenseApi extends EventEmitter {
         host: creds.iotEndpoint,
         protocol: 'wss',
         clientId: `homebridge-xsense_${Math.random().toString(16).substring(2, 10)}`,
-        accessKeyId: creds.accessKey,
-        secretAccessKey: creds.secretKey,
+        accessKeyId: creds.accessKeyId,
+        secretAccessKey: creds.secretAccessKey,
         sessionToken: creds.sessionToken,
         reconnectPeriod: 5000,
       } as any));

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -19,8 +19,8 @@ export interface GetDeviceListResponse {
 }
 
 export interface IotCredentials {
-  accessKey: string;
-  secretKey: string;
+  accessKeyId: string;
+  secretAccessKey: string;
   sessionToken: string;
   expiration: string; // ISO 8601 date string
   iotPolicy: string;


### PR DESCRIPTION
## Summary
- update `IotCredentials` field names
- use new field names when connecting to MQTT
- adjust tests for updated credential format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869662547a083248d45ed54cc2f5825