### PR TITLE
Fix battery and IoT endpoint handling

### DIFF
--- a/__tests__/XsenseApi.test.ts
+++ b/__tests__/XsenseApi.test.ts
@@ -292,6 +292,26 @@ describe('XsenseApi', () => {
       }));
     });
 
+    it('should use host field when present', async () => {
+      nock.cleanAll();
+      const credsWithHost = { ...mockCreds, iotEndpoint: undefined, host: 'host.endpoint' };
+      nock(API_HOST)
+        .post('/app')
+        .reply(200, { reCode: 200, reData: [{ houseId: 'h1', mqttServer: 'house.endpoint' }] })
+        .post('/app')
+        .reply(200, { reCode: 200, reData: { stations: mockDevices.map(d => ({ stationSn: d.station_sn, stationName: d.device_name, devices: [d] })) } });
+      nock(API_HOST)
+        .post('/app')
+        .reply(200, { reCode: 200, reData: credsWithHost });
+
+      await api.getDeviceList();
+      await api.connectMqtt();
+
+      expect(mockedMqttConnect).toHaveBeenCalledWith(expect.objectContaining({
+        host: credsWithHost.host,
+      }));
+    });
+
     it('should fallback to device mqttServer when endpoint absent', async () => {
       nock.cleanAll();
       const credsNoEndpoint = { ...mockCreds, iotEndpoint: undefined };

--- a/src/accessories/SmokeAndCOSensorAccessory.ts
+++ b/src/accessories/SmokeAndCOSensorAccessory.ts
@@ -54,10 +54,11 @@ export class SmokeAndCOSensorAccessory {
    */
   public updateFromDeviceInfo(device: DeviceInfo): void {
     this.platform.log.debug(`Updating ${this.accessory.displayName} from initial info:`, device.status);
-    const battery = device.status.battery ?? device.status.batteryLevel ??
-      (device.status as any).battery_level ??
-      (device.status as any).batteryPercentage ??
-      (device.status as any).battery_percentage;
+    const status: any = device.status as any;
+    const battery = status.battery ?? status.batteryLevel ??
+      status.battery_level ??
+      status.batteryPercentage ??
+      status.battery_percentage;
     this.updateBattery(battery);
   }
 

--- a/src/accessories/SmokeAndCOSensorAccessory.ts
+++ b/src/accessories/SmokeAndCOSensorAccessory.ts
@@ -54,7 +54,11 @@ export class SmokeAndCOSensorAccessory {
    */
   public updateFromDeviceInfo(device: DeviceInfo): void {
     this.platform.log.debug(`Updating ${this.accessory.displayName} from initial info:`, device.status);
-    this.updateBattery(device.status.battery);
+    const battery = device.status.battery ?? device.status.batteryLevel ??
+      (device.status as any).battery_level ??
+      (device.status as any).batteryPercentage ??
+      (device.status as any).battery_percentage;
+    this.updateBattery(battery);
   }
 
   /**
@@ -63,8 +67,10 @@ export class SmokeAndCOSensorAccessory {
    */
   public updateFromShadow(shadow: any): void {
     this.platform.log.debug(`Updating ${this.accessory.displayName} from shadow:`, shadow);
-    if (shadow.battery !== undefined) {
-      this.updateBattery(shadow.battery);
+    const battery = shadow.battery ?? shadow.batteryLevel ?? shadow.battery_level ??
+      shadow.batteryPercentage ?? shadow.battery_percentage;
+    if (battery !== undefined) {
+      this.updateBattery(battery);
     }
   }
 
@@ -103,7 +109,7 @@ export class SmokeAndCOSensorAccessory {
 
   private updateBattery(level?: number): void {
     if (typeof level !== 'number' || !Number.isFinite(level)) {
-      this.platform.log.warn(`[${this.accessory.displayName}] Invalid battery level received: ${level}`);
+      this.platform.log.debug(`[${this.accessory.displayName}] Ignoring invalid battery level: ${level}`);
       return;
     }
 


### PR DESCRIPTION
## Summary
- fallback to more battery level keys
- ignore invalid battery level values
- handle alternate IoT endpoint fields
- sanitize MQTT endpoint before connecting
- test IoT endpoint host fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686981db86848324829f13c7285f917a