### PR TITLE
Fix MQTT endpoint fallback

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -6,6 +6,7 @@ export interface DeviceInfo {
   type_id: number;
   device_model: string;
   mqttServer?: string;
+  mqttRegion?: string;
   status: {
     battery: number;
     online: number;


### PR DESCRIPTION
## Summary
- support `mqttRegion` when listing devices
- fall back to `mqttRegion` when credentials do not contain an MQTT endpoint
- adjust unit tests for new field and add a test for the new fallback

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869867e6fe88324a8a92ff884f03f34