### PR TITLE
Sign MQTT WebSocket with SigV4

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,16 @@ This is a [Homebridge](https://homebridge.io) plugin for integrating X-Sense smo
     *   Low Battery Warnings
 *   **Automatic Discovery:** Automatically discovers all sensors linked to your X-Sense account.
 *   **Resilient:** Automatically handles token refreshes and connection recovery.
+*   **Secure Connection:** Temporary AWS credentials are used to sign the MQTT
+    WebSocket URL via SigV4.
 
 ## Installation
 
 1.  Install Homebridge using the [official instructions](https://github.com/homebridge/homebridge/wiki).
 2.  Install this plugin using the Homebridge UI or `npm install -g homebridge-x-sense`.
 3.  Configure the plugin using the Homebridge UI or by manually editing your `config.json` file.
+4.  The plugin uses temporary AWS credentials from X-Sense to sign the MQTT
+    WebSocket connection.
 
 ## Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "amazon-cognito-identity-js": "^6.3.1",
+        "aws4": "^1.13.2",
         "axios": "^1.6.2",
         "mqtt": "^5.3.4"
       },
       "devDependencies": {
+        "@types/aws4": "^1.11.6",
         "@types/jest": "^29.5.11",
         "@types/node": "^20.12.12",
         "@types/ws": "^8.18.1",
@@ -1553,6 +1555,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/aws4": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@types/aws4/-/aws4-1.11.6.tgz",
+      "integrity": "sha512-5CnVUkHNyLGpD9AnOcK66YyP0qvIh6nhJJoeK8zSl5YKikUcUbdB7SlHevUYVqicgeh6j5AJa1qa/h08dSZHoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2121,6 +2133,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "license": "MIT"
     },
     "node_modules/axios": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -41,10 +41,12 @@
   },
   "dependencies": {
     "amazon-cognito-identity-js": "^6.3.1",
+    "aws4": "^1.13.2",
     "axios": "^1.6.2",
     "mqtt": "^5.3.4"
   },
   "devDependencies": {
+    "@types/aws4": "^1.11.6",
     "@types/jest": "^29.5.11",
     "@types/node": "^20.12.12",
     "@types/ws": "^8.18.1",


### PR DESCRIPTION
## Summary
- sign the MQTT websocket URL using `aws4`
- update tests for the new signing behaviour
- mention AWS credential usage in the README

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68698d692e608324bc6a63fd23b958a3