### PR TITLE
Fix MQTT endpoint discovery and signing

### DIFF
--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -2,6 +2,7 @@
  * Constants sourced from the X-Sense (Android) app and python-xsense library.
  */
 export const API_HOST = 'https://api.x-sense-iot.com';
+export const IOT_ENDPOINT_URL = 'https://api.x-sense.com/v1/user/iot-endpoint';
 export const CLIENT_TYPE = '1';
 export const APP_VERSION = 'v1.22.0_20240914.1';
 export const APP_CODE = '1220';


### PR DESCRIPTION
## Summary
- add `IOT_ENDPOINT_URL` constant
- add `getIotEndpoint` API call and cache
- sign MQTT connection using SigV4 headers
- update unit tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686994f395fc8324bdd3464c14fdd431