### PR TITLE
feat: added support for XS0B-iR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-x-sense",
-  "version": "0.16.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-x-sense",
-      "version": "0.16.0",
+      "version": "0.24.0",
       "cpu": [
         "arm",
         "x64",

--- a/src/api/XsenseApi.ts
+++ b/src/api/XsenseApi.ts
@@ -266,7 +266,7 @@ export class XsenseApi extends EventEmitter {
             device_model: station.category ?? 'unknown',
             mqttServer: house.mqttServer ?? house.mqtt_server,
             mqttRegion: house.mqttRegion ?? house.mqtt_region,
-            status: { battery: 0, online: station.onLine ?? 0 },
+            status: { online: station.onLine ?? 0 },
           });
         }
       }

--- a/src/api/XsenseApi.ts
+++ b/src/api/XsenseApi.ts
@@ -240,17 +240,33 @@ export class XsenseApi extends EventEmitter {
     for (const house of houses) {
       const stationData = await this.apiCall<any>('103007', { houseId: house.houseId, utctimestamp: '0' });
       for (const station of stationData.stations ?? []) {
-        for (const d of station.devices ?? []) {
+        if ((station.devices ?? []).length > 0) {
+          for (const d of station.devices) {
+            devices.push({
+              station_sn: station.stationSn,
+              station_name: station.stationName,
+              device_id: d.deviceId,
+              device_name: d.deviceName,
+              type_id: d.deviceType,
+              device_model: d.deviceModel ?? d.deviceType,
+              mqttServer: house.mqttServer ?? house.mqtt_server,
+              mqttRegion: house.mqttRegion ?? house.mqtt_region,
+              status: d.status ?? {},
+            });
+          }
+        } else {
+          // Standalone device (e.g. XS0B-iR) where the station itself is the device
+          this.log.debug(`Station ${station.stationSn} has no sub-devices, treating as standalone device (${station.category}).`);
           devices.push({
             station_sn: station.stationSn,
             station_name: station.stationName,
-            device_id: d.deviceId,
-            device_name: d.deviceName,
-            type_id: d.deviceType,
-            device_model: d.deviceModel ?? d.deviceType,
+            device_id: station.stationSn,
+            device_name: station.stationName,
+            type_id: 0,
+            device_model: station.category ?? 'unknown',
             mqttServer: house.mqttServer ?? house.mqtt_server,
             mqttRegion: house.mqttRegion ?? house.mqtt_region,
-            status: d.status ?? {},
+            status: { battery: 0, online: station.onLine ?? 0 },
           });
         }
       }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -13,7 +13,7 @@ export interface DeviceInfo {
   mqttServer?: string;
   mqttRegion?: string;
   status: {
-    battery: number;
+    battery?: number;
     online: number;
     // ... other status properties
   };

--- a/src/deviceCapabilities.ts
+++ b/src/deviceCapabilities.ts
@@ -15,6 +15,7 @@ const MODEL_CAPABILITIES: Record<string, DeviceCapability[]> = {
   'XS01-WX': [DeviceCapability.Smoke],
   'XS03-iWX': [DeviceCapability.Smoke],
   'XS03-WX': [DeviceCapability.Smoke],
+  'XS0B-iR': [DeviceCapability.Smoke],
   'XS0D-MR': [DeviceCapability.Smoke],
 };
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -56,8 +56,16 @@ export class XSenseHomebridgePlatform implements DynamicPlatformPlugin {
       const devices = await this.xsenseApi.getDeviceList();
       this.log.info(`Discovered ${devices.length} devices.`);
 
-      // Filter for actual sensors, not base stations which don't have their own sensors
-      const sensorDevices = devices.filter(d => d.device_id !== d.station_sn);
+      // Filter for actual sensors. Standalone devices (where device_id === station_sn)
+      // are kept if they have a known device model with capabilities.
+      const sensorDevices = devices.filter(d => {
+        if (d.device_id !== d.station_sn) {
+          return true; // Sub-device of a base station
+        }
+        // Standalone device — include if we recognise it
+        const caps = detectCapabilities(d.device_model);
+        return caps.length > 0;
+      });
       const cachedAccessories = [...this.accessories];
 
       this.log.info(`Found ${sensorDevices.length} sensor devices to register.`);


### PR DESCRIPTION
Added support for XS0B-iR , also added support to lookup of non-station devices where the device itself is the station like the XS0B-iR being a standalone device. 

Tested locally and confirmed working. 